### PR TITLE
Make one assertion per test.

### DIFF
--- a/spec/defines/sftp_jail_single_spec.rb
+++ b/spec/defines/sftp_jail_single_spec.rb
@@ -16,44 +16,59 @@ describe 'sftp_jail::single', :type => :define do
       :kernel                 => 'Linux',
     }
   end
-  describe "compiles" do
-    let :title do
-      'test'
-    end
-    let :params do
-      {
-        :jail_user  => 'bob',
-        :jail_group => 'bob',
+  let :title do
+    'test'
+  end
+  let :params do
+    {
+      :jail_user  => 'bob',
+      :jail_group => 'bob',
+    }
+  end
+  it { is_expected.to compile }
+  it { is_expected.to contain_class('sftp_jail') }
+  it 'manages base folder' do
+    is_expected.to contain_file('/chroot/test/').with({
+      'ensure' => 'directory',
+      'owner'  => 'root',
+      'group'  => 'root',
+      'mode'   => '0755',
+    })
+  end
+  it 'manages an incoming directory' do
+    is_expected.to contain_file('/chroot/test/incoming').with({
+      'ensure' => 'directory',
+      'owner'  => 'bob',
+      'group'  => 'bob',
+      'mode'   => '0775',
+    })
+  end
+  it 'manages a home directory' do
+    is_expected.to contain_file('/chroot/test/home').with({
+      'ensure' => 'directory',
+      'owner'  => 'bob',
+      'group'  => 'bob',
+      'mode'   => '0775',
+    })
+  end
+  it 'manages a users home directory' do
+    is_expected.to contain_file('/chroot/test/home/bob').with({
+      'ensure' => 'directory',
+      'owner'  => 'bob',
+      'group'  => 'bob',
+      'mode'   => '0775',
+    })
+  end
+  it 'adds an ssh server entry for the user' do
+    is_expected.to contain_ssh__server__match_block('bob').with({
+      'type' => 'Group',
+      'options' => {
+        'ChrootDirectory'        => '/chroot/test',
+        'ForceCommand'           => 'internal-sftp',
+        'PasswordAuthentication' => 'no',
+        'AllowTcpForwarding'     => 'no',
+        'X11Forwarding'          => 'no',
       }
-    end
-    it { is_expected.to compile }
-    it { is_expected.to contain_class('sftp_jail') }
-    it do
-      is_expected.to contain_file('/chroot/test/').with({
-        'ensure' => 'directory',
-        'owner'  => 'root',
-        'group'  => 'root',
-        'mode'   => '0755',
-      })
-      is_expected.to contain_file('/chroot/test/incoming').with({
-        'ensure' => 'directory',
-        'owner'  => 'bob',
-        'group'  => 'bob',
-        'mode'   => '0775',
-     })
-      is_expected.to contain_file('/chroot/test/home').with({
-        'ensure' => 'directory',
-        'owner'  => 'bob',
-        'group'  => 'bob',
-        'mode'   => '0775',
-      })
-      is_expected.to contain_file('/chroot/test/home/bob').with({
-        'ensure' => 'directory',
-        'owner'  => 'bob',
-        'group'  => 'bob',
-        'mode'   => '0775',
-      })
-      is_expected.to create_ssh__server__match_block('bob')
-    end
+    })
   end
 end


### PR DESCRIPTION
This also fleshes out the test for the ssh::server::match_block's
attributes.